### PR TITLE
Add support for MyntEye S camera

### DIFF
--- a/orb_slam2/config/mynteye_s_mono.yaml
+++ b/orb_slam2/config/mynteye_s_mono.yaml
@@ -1,0 +1,63 @@
+%YAML:1.0
+
+#--------------------------------------------------------------------------------------------
+# Camera Parameters. Adjust them!
+#--------------------------------------------------------------------------------------------
+
+# Camera calibration and distortion parameters (OpenCV) 
+Camera.fx: 332.97713134460906
+Camera.fy: 332.97713134460906
+Camera.cx: 398.9270935058594
+Camera.cy: 252.28187370300293
+
+Camera.k1: 0.0
+Camera.k2: 0.0
+Camera.p1: 0.0
+Camera.p2: 0.0
+
+Camera.width: 752
+Camera.height: 480
+
+# Camera frames per second 
+Camera.fps: 30.0
+
+# stereo baseline times fx
+Camera.bf: 47.90639384423901
+
+# Color order of the images (0: BGR, 1: RGB. It is ignored if images are grayscale)
+Camera.RGB: 1
+
+#--------------------------------------------------------------------------------------------
+# ORB Parameters
+#--------------------------------------------------------------------------------------------
+
+# ORB Extractor: Number of features per image
+ORBextractor.nFeatures: 1200
+
+# ORB Extractor: Scale factor between levels in the scale pyramid 	
+ORBextractor.scaleFactor: 1.2
+
+# ORB Extractor: Number of levels in the scale pyramid	
+ORBextractor.nLevels: 8
+
+# ORB Extractor: Fast threshold
+# Image is divided in a grid. At each cell FAST are extracted imposing a minimum response.
+# Firstly we impose iniThFAST. If no corners are detected we impose a lower value minThFAST
+# You can lower these values if your images have low contrast			
+ORBextractor.iniThFAST: 20
+ORBextractor.minThFAST: 7
+
+#--------------------------------------------------------------------------------------------
+# Viewer Parameters
+#--------------------------------------------------------------------------------------------
+Viewer.KeyFrameSize: 0.05
+Viewer.KeyFrameLineWidth: 1
+Viewer.GraphLineWidth: 0.9
+Viewer.PointSize:2
+Viewer.CameraSize: 0.08
+Viewer.CameraLineWidth: 3
+Viewer.ViewpointX: 0
+Viewer.ViewpointY: -0.7
+Viewer.ViewpointZ: -1.8
+Viewer.ViewpointF: 500
+

--- a/orb_slam2/config/mynteye_s_stereo.yaml
+++ b/orb_slam2/config/mynteye_s_stereo.yaml
@@ -1,0 +1,116 @@
+%YAML:1.0
+
+#--------------------------------------------------------------------------------------------
+# Camera Parameters. Adjust them!
+#--------------------------------------------------------------------------------------------
+
+# Camera calibration and distortion parameters (OpenCV) 
+Camera.fx: 332.97713134460906
+Camera.fy: 332.97713134460906
+Camera.cx: 398.9270935058594
+Camera.cy: 252.28187370300293
+
+Camera.k1: 0.0
+Camera.k2: 0.0
+Camera.p1: 0.0
+Camera.p2: 0.0
+
+Camera.width: 752
+Camera.height: 480
+
+# Camera frames per second 
+Camera.fps: 30.0
+
+# stereo baseline times fx
+Camera.bf: 47.90639384423901
+
+# Color order of the images (0: BGR, 1: RGB. It is ignored if images are grayscale)
+Camera.RGB: 1
+
+# Close/Far threshold. Baseline times.
+ThDepth: 35
+
+#--------------------------------------------------------------------------------------------
+# Stereo Rectification. Only if you need to pre-rectify the images.
+# Camera.fx, .fy, etc must be the same as in LEFT.P
+#--------------------------------------------------------------------------------------------
+LEFT.height: 480
+LEFT.width: 752
+LEFT.D: !!opencv-matrix
+   rows: 1
+   cols: 5
+   dt: d
+   data: [-0.27186431380704884, 0.05397709169334604, -0.000557307377524114, -0.0006127379205397152, 0.0]
+LEFT.K: !!opencv-matrix
+   rows: 3
+   cols: 3
+   dt: d
+   data: [360.0652897865692, 0.0, 406.6650580307593, 0.0, 363.2195731683743, 256.20533579714373, 0.0, 0.0, 1.0]
+LEFT.R:  !!opencv-matrix
+   rows: 3
+   cols: 3
+   dt: d
+   data: [0.9995051975828172, -0.004232452030025982, 0.031168034181628675, 0.00404399044045864, 0.9999731738419173, 0.006107187391924209, -0.031193046440691295, -0.005978122308562103, 0.9994955006939314]
+LEFT.P:  !!opencv-matrix
+   rows: 3
+   cols: 4
+   dt: d
+   data: [332.97713134460906, 0.0, 398.9270935058594, 0.0, 0.0, 332.97713134460906, 252.28187370300293, 0.0, 0.0, 0.0, 1.0, 0.0]
+
+RIGHT.height: 480
+RIGHT.width: 752
+RIGHT.D: !!opencv-matrix
+   rows: 1
+   cols: 5
+   dt: d
+   data:[-0.2608724975841786, 0.04949670859088579, -0.00033079602477046385, 0.002888671484465195, 0.0]
+RIGHT.K: !!opencv-matrix
+   rows: 3
+   cols: 3
+   dt: d
+   data: [362.3216398160725, 0.0, 356.12189598153714, 0.0, 365.90199497184676, 255.37341022147191, 0.0, 0.0, 1.0]
+RIGHT.R:  !!opencv-matrix
+   rows: 3
+   cols: 3
+   dt: d
+   data: [0.9971385096122076, -0.004423319050556735, -0.07546672708500173, 0.003966835741299504, 0.9999729264511134, -0.006197626884355805, 0.0754920980139425, 0.005880528324319419, 0.9971290601141259]
+RIGHT.P:  !!opencv-matrix
+   rows: 3
+   cols: 4
+   dt: d
+   data: [332.97713134460906, 0.0, 398.9270935058594, -39.71778017327359, 0.0, 332.97713134460906, 252.28187370300293, 0.0, 0.0, 0.0, 1.0, 0.0]
+
+#--------------------------------------------------------------------------------------------
+# ORB Parameters
+#--------------------------------------------------------------------------------------------
+
+# ORB Extractor: Number of features per image
+ORBextractor.nFeatures: 1200
+
+# ORB Extractor: Scale factor between levels in the scale pyramid 	
+ORBextractor.scaleFactor: 1.2
+
+# ORB Extractor: Number of levels in the scale pyramid	
+ORBextractor.nLevels: 8
+
+# ORB Extractor: Fast threshold
+# Image is divided in a grid. At each cell FAST are extracted imposing a minimum response.
+# Firstly we impose iniThFAST. If no corners are detected we impose a lower value minThFAST
+# You can lower these values if your images have low contrast			
+ORBextractor.iniThFAST: 20
+ORBextractor.minThFAST: 7
+
+#--------------------------------------------------------------------------------------------
+# Viewer Parameters
+#--------------------------------------------------------------------------------------------
+Viewer.KeyFrameSize: 0.05
+Viewer.KeyFrameLineWidth: 1
+Viewer.GraphLineWidth: 0.9
+Viewer.PointSize:2
+Viewer.CameraSize: 0.08
+Viewer.CameraLineWidth: 3
+Viewer.ViewpointX: 0
+Viewer.ViewpointY: -0.7
+Viewer.ViewpointZ: -1.8
+Viewer.ViewpointF: 500
+

--- a/ros/launch/orb_slam2_mynteye_s_mono.launch
+++ b/ros/launch/orb_slam2_mynteye_s_mono.launch
@@ -1,0 +1,16 @@
+<launch>
+  <node name="orb_slam2_mono" pkg="orb_slam2_ros"
+      type="orb_slam2_ros_mono" args="
+          $(find orb_slam2_ros)/orb_slam2/Vocabulary/ORBvoc.txt
+          $(find orb_slam2_ros)/orb_slam2/config/mynteye_s_mono.yaml"
+      output="screen">
+       <remap from="/camera/image_raw" to="/mynteye/left_rect/image_rect" />
+
+       <param name="publish_pointcloud" type="bool" value="true" />
+       <param name="localize_only" type="bool" value="false" />
+       <param name="reset_map" type="bool" value="false" />
+       <param name="pointcloud_frame_id" type="string" value="map" />
+       <param name="camera_frame_id" type="string" value="camera_link" />
+       <param name="min_num_kf_in_map" type="int" value="5" />
+  </node>
+</launch>

--- a/ros/launch/orb_slam2_mynteye_s_stereo.launch
+++ b/ros/launch/orb_slam2_mynteye_s_stereo.launch
@@ -1,0 +1,14 @@
+<launch>
+  <node name="orb_slam2_stereo" pkg="orb_slam2_ros"
+      type="orb_slam2_ros_stereo" args="
+          $(find orb_slam2_ros)/orb_slam2/Vocabulary/ORBvoc.txt
+          $(find orb_slam2_ros)/orb_slam2/config/mynteye_s_stereo.yaml"
+      output="screen">
+       <remap from="image_left/image_color_rect" to="/mynteye/left_rect/image_rect" />
+       <remap from="image_right/image_color_rect" to="/mynteye/right_rect/image_rect" />
+
+       <param name="publish_pointcloud" type="bool" value="true" />
+       <param name="pointcloud_frame_id" type="string" value="map" />
+       <param name="camera_frame_id" type="string" value="camera_link" />
+  </node>
+</launch>


### PR DESCRIPTION
This PR adds support for [MyntEye S stereo camera](https://www.mynteye.com/products/mynt-eye-stereo-camera). The changes include:

- Add yaml config files.
- Add launch files for mono and stereo use cases.

How to use (suppose you have the camera hardware):

- Install the [Mynt Eye SDK](https://github.com/slightech/MYNT-EYE-ORB-SLAM2-Sample#ssdkinstall).
- Perform [calibration](http://wiki.ros.org/camera_calibration) for your own device. 
- Launch ROS wrapper for the camera: `roslaunch mynt_eye_ros_wrapper mynteye.launch`.
- Launch orb_slam2: 
`
roslaunch orb_slam2_ros orb_slam2_mynteye_s_mono.launch 
`
or
`
roslaunch orb_slam2_ros orb_slam2_mynteye_s_stereo.launch 
`

I have done some handheld tests and everything seems to work OK. Please let me know if there is anything that needs to be modified.