### PR TITLE
Pose publisher

### DIFF
--- a/ros/include/Node.h
+++ b/ros/include/Node.h
@@ -37,6 +37,7 @@
 #include <message_filters/sync_policies/approximate_time.h>
 #include <sensor_msgs/image_encodings.h>
 #include <sensor_msgs/PointCloud2.h>
+#include <geometry_msgs/PoseStamped.h>
 
 #include "System.h"
 
@@ -57,6 +58,7 @@ class Node
   private:
     void PublishMapPoints (std::vector<ORB_SLAM2::MapPoint*> map_points);
     void PublishPositionAsTransform (cv::Mat position);
+    void PublishPositionAsPoseStamped(cv::Mat position);
     void PublishRenderedImage (cv::Mat image);
     void ParamsChangedCallback(orb_slam2_ros::dynamic_reconfigureConfig &config, uint32_t level);
     tf::Transform TransformFromMat (cv::Mat position_mat);
@@ -66,6 +68,7 @@ class Node
 
     image_transport::Publisher rendered_image_publisher_;
     ros::Publisher map_points_publisher_;
+    ros::Publisher pose_publisher_;
 
     std::string name_of_node_;
     ros::NodeHandle node_handle_;
@@ -73,6 +76,7 @@ class Node
     std::string map_frame_id_param_;
     std::string camera_frame_id_param_;
     bool publish_pointcloud_param_;
+    bool publish_pose_param_;
     int min_observations_per_point_;
 };
 

--- a/ros/launch/orb_slam2_d435_mono.launch
+++ b/ros/launch/orb_slam2_d435_mono.launch
@@ -7,6 +7,7 @@
        <remap from="/camera/image_raw" to="/camera/color/image_raw" />
 
        <param name="publish_pointcloud" type="bool" value="true" />
+       <param name="publish_pose" type="bool" value="true" />
        <param name="localize_only" type="bool" value="false" />
        <param name="reset_map" type="bool" value="false" />
        <param name="pointcloud_frame_id" type="string" value="map" />

--- a/ros/launch/orb_slam2_d435_rgbd.launch
+++ b/ros/launch/orb_slam2_d435_rgbd.launch
@@ -8,6 +8,7 @@
        <remap from="/camera/depth_registered/image_raw" to="/camera/depth/image_rect_raw" />
 
        <param name="publish_pointcloud" type="bool" value="true" />
+       <param name="publish_pose" type="bool" value="true" />
        <param name="localize_only" type="bool" value="false" />
        <param name="reset_map" type="bool" value="false" />
        <param name="pointcloud_frame_id" type="string" value="map" />

--- a/ros/launch/orb_slam2_mynteye_s_mono.launch
+++ b/ros/launch/orb_slam2_mynteye_s_mono.launch
@@ -7,6 +7,7 @@
        <remap from="/camera/image_raw" to="/mynteye/left_rect/image_rect" />
 
        <param name="publish_pointcloud" type="bool" value="true" />
+       <param name="publish_pose" type="bool" value="true" />
        <param name="localize_only" type="bool" value="false" />
        <param name="reset_map" type="bool" value="false" />
        <param name="pointcloud_frame_id" type="string" value="map" />

--- a/ros/launch/orb_slam2_mynteye_s_stereo.launch
+++ b/ros/launch/orb_slam2_mynteye_s_stereo.launch
@@ -8,6 +8,7 @@
        <remap from="image_right/image_color_rect" to="/mynteye/right_rect/image_rect" />
 
        <param name="publish_pointcloud" type="bool" value="true" />
+       <param name="publish_pose" type="bool" value="true" />
        <param name="pointcloud_frame_id" type="string" value="map" />
        <param name="camera_frame_id" type="string" value="camera_link" />
   </node>

--- a/ros/launch/orb_slam2_r200_mono.launch
+++ b/ros/launch/orb_slam2_r200_mono.launch
@@ -7,6 +7,7 @@
        <remap from="/camera/image_raw" to="/camera/rgb/image_raw" />
 
        <param name="publish_pointcloud" type="bool" value="true" />
+       <param name="publish_pose" type="bool" value="true" />
        <param name="pointcloud_frame_id" type="string" value="map" />
        <param name="camera_frame_id" type="string" value="camera_link" />
   </node>

--- a/ros/launch/orb_slam2_r200_rgbd.launch
+++ b/ros/launch/orb_slam2_r200_rgbd.launch
@@ -8,6 +8,7 @@
        <remap from="/camera/depth_registered/image_raw" to="/camera/depth_registered/sw_registered/image_rect" />
 
        <param name="publish_pointcloud" type="bool" value="true" />
+       <param name="publish_pose" type="bool" value="true" />
        <param name="pointcloud_frame_id" type="string" value="map" />
        <param name="camera_frame_id" type="string" value="camera_link" />>
   </node>

--- a/ros/launch/orb_slam2_r200_stereo.launch
+++ b/ros/launch/orb_slam2_r200_stereo.launch
@@ -8,6 +8,7 @@
        <remap from="image_right/image_color_rect" to="/cam_front/right/image_rect_color" />
 
        <param name="publish_pointcloud" type="bool" value="true" />
+       <param name="publish_pose" type="bool" value="true" />
        <param name="pointcloud_frame_id" type="string" value="map" />
        <param name="camera_frame_id" type="string" value="camera_link" />
   </node>

--- a/ros/src/Node.cc
+++ b/ros/src/Node.cc
@@ -23,7 +23,11 @@ Node::Node (ORB_SLAM2::System* pSLAM, ros::NodeHandle &node_handle, image_transp
   if (publish_pointcloud_param_) {
     map_points_publisher_ = node_handle_.advertise<sensor_msgs::PointCloud2> (name_of_node_+"/map_points", 1);
   }
-  pose_publisher_ = node_handle_.advertise<geometry_msgs::PoseStamped> (name_of_node_+"/pose", 1);
+
+  // Enable publishing camera's pose as PoseStamped message
+  if (publish_pose_param_) {
+    pose_publisher_ = node_handle_.advertise<geometry_msgs::PoseStamped> (name_of_node_+"/pose", 1);
+  }
 }
 
 


### PR DESCRIPTION
This PR adds a ROS publisher of type `geometry_msgs/PoseStamped`, publishing the camera relative poses on a topic named `pose`.

- All changes reside in `Node.cc` and `Node.h` files. 
- A new param named `publish_pose` is added in all launch files to enable/disable publishing this topic.

Having a `PoseStamped` message is useful in certain cases where other packages accept this type of message but not `tf`.  Of course, when `tf` is enough user can disable it at will.