### PR TITLE
Fix build with gcc9

### DIFF
--- a/orb_slam2/include/LoopClosing.h
+++ b/orb_slam2/include/LoopClosing.h
@@ -47,7 +47,7 @@ public:
 
     typedef pair<set<KeyFrame*>,int> ConsistentGroup;    
     typedef map<KeyFrame*,g2o::Sim3,std::less<KeyFrame*>,
-        Eigen::aligned_allocator<std::pair<const KeyFrame*, g2o::Sim3> > > KeyFrameAndPose;
+        Eigen::aligned_allocator<std::pair<KeyFrame* const, g2o::Sim3> > > KeyFrameAndPose;
 
 public:
 


### PR DESCRIPTION
craymichael fixed this over 1 year ago and proposed it to the now dead original upstream. Please take this patch to fix the build on modern compilers. 
https://github.com/raulmur/ORB_SLAM2/pull/585

Build error: 
```
Errors     << orb_slam2_ros:make /home/jessi/catkin_ws/logs/orb_slam2_ros/build.make.001.log 
In file included from /usr/include/c++/9.2.0/map:61,
                 from /home/jessi/catkin_ws/src/orb_slam_2_ros/orb_slam2/Thirdparty/DBoW2/DBoW2/BowVector.h:14,
                 from /home/jessi/catkin_ws/src/orb_slam_2_ros/orb_slam2/include/Frame.h:27,
                 from /home/jessi/catkin_ws/src/orb_slam_2_ros/orb_slam2/include/MapPoint.h:25,
                 from /home/jessi/catkin_ws/src/orb_slam_2_ros/orb_slam2/include/KeyFrame.h:24,
                 from /home/jessi/catkin_ws/src/orb_slam_2_ros/orb_slam2/include/LoopClosing.h:24,
                 from /home/jessi/catkin_ws/src/orb_slam_2_ros/orb_slam2/src/LoopClosing.cc:21:
/usr/include/c++/9.2.0/bits/stl_map.h: In instantiation of ‘class std::map<ORB_SLAM2::KeyFrame*, g2o::Sim3, std::less<ORB_SLAM2::KeyFrame*>, Eigen::aligned_allocator<std::pair<const ORB_SLAM2::KeyFrame*, g2o::Sim3> > >’:
/home/jessi/catkin_ws/src/orb_slam_2_ros/orb_slam2/src/LoopClosing.cc:438:21:   required from here
/usr/include/c++/9.2.0/bits/stl_map.h:122:71: error: static assertion failed: std::map must have the same value_type as its allocator
  122 |       static_assert(is_same<typename _Alloc::value_type, value_type>::value,
      |                                                                       ^~~~~
In file included from /usr/include/c++/9.2.0/map:61,
                 from /home/jessi/catkin_ws/src/orb_slam_2_ros/orb_slam2/Thirdparty/DBoW2/DBoW2/BowVector.h:14,
                 from /home/jessi/catkin_ws/src/orb_slam_2_ros/orb_slam2/include/KeyFrame.h:25,
                 from /home/jessi/catkin_ws/src/orb_slam_2_ros/orb_slam2/include/MapPoint.h:24,
                 from /home/jessi/catkin_ws/src/orb_slam_2_ros/orb_slam2/include/Map.h:24,
                 from /home/jessi/catkin_ws/src/orb_slam_2_ros/orb_slam2/include/Optimizer.h:24,
                 from /home/jessi/catkin_ws/src/orb_slam_2_ros/orb_slam2/src/Optimizer.cc:21:
/usr/include/c++/9.2.0/bits/stl_map.h: In instantiation of ‘class std::map<ORB_SLAM2::KeyFrame*, g2o::Sim3, std::less<ORB_SLAM2::KeyFrame*>, Eigen::aligned_allocator<std::pair<const ORB_SLAM2::KeyFrame*, g2o::Sim3> > >’:
/home/jessi/catkin_ws/src/orb_slam_2_ros/orb_slam2/src/Optimizer.cc:818:37:   required from here
/usr/include/c++/9.2.0/bits/stl_map.h:122:71: error: static assertion failed: std::map must have the same value_type as its allocator
  122 |       static_assert(is_same<typename _Alloc::value_type, value_type>::value,
      |                                                                       ^~~~~
make[2]: *** [CMakeFiles/orb_slam2_ros.dir/build.make:102: CMakeFiles/orb_slam2_ros.dir/orb_slam2/src/LoopClosing.cc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: *** [CMakeFiles/orb_slam2_ros.dir/build.make:206: CMakeFiles/orb_slam2_ros.dir/orb_slam2/src/Optimizer.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:250: CMakeFiles/orb_slam2_ros.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
cd /home/jessi/catkin_ws/build/orb_slam2_ros; catkin build --get-env orb_slam2_ros | catkin env -si  /usr/bin/make --jobserver-auth=3,4; cd -
```