### PR TITLE
fix maps cannot be saved multiple times

### DIFF
--- a/orb_slam2/src/System.cc
+++ b/orb_slam2/src/System.cc
@@ -513,7 +513,7 @@ bool System::SetCallStackSize (const rlim_t kNewStackSize) {
         return false;
     }
 
-    if (rlimit.rlim_cur < kNewStackSize) {
+    if (rlimit.rlim_cur <= kNewStackSize) {
         rlimit.rlim_cur = kNewStackSize;
         operation_result = setrlimit(RLIMIT_STACK, &rlimit);
         if (operation_result != 0) {


### PR DESCRIPTION
in System::SetCallStackSize(), 'rlimit.rlim_cur == kNewStackSize' should not be consider as an error.

Otherwise,  the second time the  service `rosservice call /orb_slam2_rgbd/save_map "name: 'map.bin'" `
 is called, it may report the following error:
`Error changing the call stack size; Aborting.` 
