### PR TITLE
Removed unused 'settings_file' param

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,11 @@ The config files for camera calibration and tracking hyper paramters from the or
 
 ## ROS parameters, topics and services
 ### Parameters
-There are three types of parameters right now: static- and dynamic ros parameters and camera settings from the config file.
+There are three types of parameters right now: static- and dynamic ros parameters and camera settings.
 The static parameters are send to the ROS parameter server at startup and are not supposed to change. They are set in the launch files which are located at ros/launch. The parameters are:
 
 - **load_map**: Bool. If set to true, the node will try to load the map provided with map_file at startup.
 - **map_file**: String. The name of the file the map is loaded from.
-- **settings_file**: String. The location of config file mentioned above.
 - **voc_file**: String. The location of config vocanulary file mentioned above.
 - **publish_pointcloud**: Bool. If the pointcloud containing all key points (the map) should be published.
 - **publish_pose**: Bool. If a PoseStamped message should be published. Even if this is false the tf will still be published.

--- a/ros/include/Node.h
+++ b/ros/include/Node.h
@@ -88,7 +88,6 @@ class Node
     std::string camera_frame_id_param_;
     std::string map_file_name_param_;
     std::string voc_file_name_param_;
-    std::string settings_file_name_param_;
     bool load_map_param_;
     bool publish_pointcloud_param_;
     bool publish_tf_param_;

--- a/ros/launch/orb_slam2_d435_rgbd.launch
+++ b/ros/launch/orb_slam2_d435_rgbd.launch
@@ -13,7 +13,6 @@
        <!-- static parameters -->
        <param name="load_map" type="bool" value="false" />
        <param name="map_file" type="string" value="map.bin" />
-       <param name="settings_file" type="string" value="$(find orb_slam2_ros)/orb_slam2/config/RealSenseD435RGBD.yaml" />
        <param name="voc_file" type="string" value="$(find orb_slam2_ros)/orb_slam2/Vocabulary/ORBvoc.txt" />
 
        <param name="pointcloud_frame_id" type="string" value="map" />

--- a/ros/launch/orb_slam2_mynteye_s_mono.launch
+++ b/ros/launch/orb_slam2_mynteye_s_mono.launch
@@ -11,7 +11,6 @@
        <!-- static parameters -->
        <param name="load_map" type="bool" value="false" />
        <param name="map_file" type="string" value="map.bin" />
-       <param name="settings_file" type="string" value="$(find orb_slam2_ros)/orb_slam2/config/mynteye_s_mono.yaml" />
        <param name="voc_file" type="string" value="$(find orb_slam2_ros)/orb_slam2/Vocabulary/ORBvoc.txt" />
 
        <param name="pointcloud_frame_id" type="string" value="map" />

--- a/ros/launch/orb_slam2_mynteye_s_stereo.launch
+++ b/ros/launch/orb_slam2_mynteye_s_stereo.launch
@@ -13,7 +13,6 @@
        <!-- static parameters -->
        <param name="load_map" type="bool" value="false" />
        <param name="map_file" type="string" value="map.bin" />
-       <param name="settings_file" type="string" value="$(find orb_slam2_ros)/orb_slam2/config/mynteye_s_stereo.yaml" />
        <param name="voc_file" type="string" value="$(find orb_slam2_ros)/orb_slam2/Vocabulary/ORBvoc.txt" />
 
        <param name="pointcloud_frame_id" type="string" value="map" />

--- a/ros/launch/orb_slam2_r200_mono.launch
+++ b/ros/launch/orb_slam2_r200_mono.launch
@@ -12,7 +12,6 @@
        <!-- static parameters -->
        <param name="load_map" type="bool" value="false" />
        <param name="map_file" type="string" value="map.bin" />
-       <param name="settings_file" type="string" value="$(find orb_slam2_ros)/orb_slam2/config/RealSenseR200Mono.yaml" />
        <param name="voc_file" type="string" value="$(find orb_slam2_ros)/orb_slam2/Vocabulary/ORBvoc.txt" />
 
        <param name="pointcloud_frame_id" type="string" value="map" />

--- a/ros/launch/orb_slam2_r200_rgbd.launch
+++ b/ros/launch/orb_slam2_r200_rgbd.launch
@@ -13,7 +13,6 @@
        <!-- static parameters -->
        <param name="load_map" type="bool" value="false" />
        <param name="map_file" type="string" value="map.bin" />
-       <param name="settings_file" type="string" value="$(find orb_slam2_ros)/orb_slam2/config/RealSenseR200RGBD.yaml" />
        <param name="voc_file" type="string" value="$(find orb_slam2_ros)/orb_slam2/Vocabulary/ORBvoc.txt" />
 
        <param name="pointcloud_frame_id" type="string" value="map" />

--- a/ros/launch/orb_slam2_r200_stereo.launch
+++ b/ros/launch/orb_slam2_r200_stereo.launch
@@ -13,7 +13,6 @@
        <!-- static parameters -->
        <param name="load_map" type="bool" value="false" />
        <param name="map_file" type="string" value="map.bin" />
-       <param name="settings_file" type="string" value="$(find orb_slam2_ros)/orb_slam2/config/RealSenseR200Stereo.yamll" />
        <param name="voc_file" type="string" value="$(find orb_slam2_ros)/orb_slam2/Vocabulary/ORBvoc.txt" />
 
        <param name="pointcloud_frame_id" type="string" value="map" />

--- a/ros/src/Node.cc
+++ b/ros/src/Node.cc
@@ -16,7 +16,6 @@ Node::Node (ORB_SLAM2::System::eSensor sensor, ros::NodeHandle &node_handle, ima
   node_handle_.param<std::string>(name_of_node_+ "/camera_frame_id", camera_frame_id_param_, "camera_link");
   node_handle_.param<std::string>(name_of_node_ + "/map_file", map_file_name_param_, "map.bin");
   node_handle_.param<std::string>(name_of_node_ + "/voc_file", voc_file_name_param_, "file_not_set");
-  node_handle_.param<std::string>(name_of_node_ + "/settings_file", settings_file_name_param_, "file_not_set");
   node_handle_.param(name_of_node_ + "/load_map", load_map_param_, false);
 
    // Create a parameters object to pass to the Tracking system


### PR DESCRIPTION
This is a suggested fix to #63 .
From what I can tell, the 'settings_file' parameter is not used at all in the current codebase, so I've removed all references to it.