### PR TITLE
Publish GBA status

### DIFF
--- a/orb_slam2/include/System.h
+++ b/orb_slam2/include/System.h
@@ -83,6 +83,9 @@ public:
     // since last call to this function
     bool MapChanged();
 
+    // Returns true if Global Bundle Adjustment is running
+    bool isRunningGBA();
+
     // Reset the system (clear map)
     void Reset();
 

--- a/orb_slam2/src/System.cc
+++ b/orb_slam2/src/System.cc
@@ -289,6 +289,11 @@ bool System::MapChanged()
         return false;
 }
 
+bool System::isRunningGBA()
+{
+    return  mpLoopCloser->isRunningGBA();
+}
+
 void System::Reset()
 {
     unique_lock<mutex> lock(mMutexReset);
@@ -602,7 +607,7 @@ bool System::SaveMap(const string &filename) {
 }
 
 bool System::LoadMap(const string &filename) {
-    
+
     unique_lock<mutex>MapPointGlobal(MapPoint::mGlobalMutex);
     std::ifstream in(filename, std::ios_base::binary);
     if (!in) {
@@ -631,19 +636,19 @@ bool System::LoadMap(const string &filename) {
 
         it->SetORBvocabulary(mpVocabulary);
         it->ComputeBoW();
-        
+
         if (it->mnFrameId > mnFrameId) {
             mnFrameId = it->mnFrameId;
         }
     }
 
     Frame::nNextId = mnFrameId;
-    
+
     std::cout << " ... done" << std::endl;
     in.close();
 
     SetCallStackSize(kDefaultCallStackSize);
-    
+
     return true;
 }
 

--- a/ros/include/Node.h
+++ b/ros/include/Node.h
@@ -41,6 +41,7 @@
 #include <sensor_msgs/PointCloud2.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <sensor_msgs/CameraInfo.h>
+#include <std_msgs/Bool.h>
 
 #include "System.h"
 
@@ -64,6 +65,7 @@ class Node
     void PublishMapPoints (std::vector<ORB_SLAM2::MapPoint*> map_points);
     void PublishPositionAsTransform (cv::Mat position);
     void PublishPositionAsPoseStamped(cv::Mat position);
+    void PublishGBAStatus (bool gba_status);
     void PublishRenderedImage (cv::Mat image);
     void ParamsChangedCallback(orb_slam2_ros::dynamic_reconfigureConfig &config, uint32_t level);
     bool SaveMapSrv (orb_slam2_ros::SaveMap::Request &req, orb_slam2_ros::SaveMap::Response &res);
@@ -77,6 +79,7 @@ class Node
     image_transport::Publisher rendered_image_publisher_;
     ros::Publisher map_points_publisher_;
     ros::Publisher pose_publisher_;
+    ros::Publisher status_gba_publisher_;
 
     ros::ServiceServer service_server_;
 

--- a/ros/src/Node.cc
+++ b/ros/src/Node.cc
@@ -53,6 +53,8 @@ void Node::Init () {
   if (publish_pose_param_) {
     pose_publisher_ = node_handle_.advertise<geometry_msgs::PoseStamped> (name_of_node_+"/pose", 1);
   }
+
+  status_gba_publisher_ = node_handle_.advertise<std_msgs::Bool> (name_of_node_+"/gba_running", 1);
 }
 
 
@@ -72,6 +74,8 @@ void Node::Update () {
   if (publish_pointcloud_param_) {
     PublishMapPoints (orb_slam_->GetAllMapPoints());
   }
+
+  PublishGBAStatus (orb_slam_->isRunningGBA());
 
 }
 
@@ -98,6 +102,11 @@ void Node::PublishPositionAsPoseStamped (cv::Mat position) {
   pose_publisher_.publish(pose_msg);
 }
 
+void Node::PublishGBAStatus (bool gba_status) {
+  std_msgs::Bool gba_status_msg;
+  gba_status_msg.data = gba_status;
+  status_gba_publisher_.publish(gba_status_msg);
+}
 
 void Node::PublishRenderedImage (cv::Mat image) {
   std_msgs::Header header;


### PR DESCRIPTION
Publishing the GBA status can be used to stop the robot during a map update (since no localization updates are done).