### PR TITLE
Fixed bug (missing tf2-geometry) in Dockerfile and added setup.bash sourcing

### DIFF
--- a/docker/kinetic/Dockerfile
+++ b/docker/kinetic/Dockerfile
@@ -25,7 +25,8 @@ RUN apt-get install software-properties-common apt-utils -y
 RUN add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main" -u
 
 # Install required realsense and ROS packages
-RUN apt-get install librealsense2-dkms librealsense2-utils librealsense2-dev librealsense2-dbg ros-kinetic-rgbd-launch python-catkin-tools -y
+RUN apt-get install librealsense2-dkms librealsense2-utils librealsense2-dev \
+    librealsense2-dbg ros-kinetic-rgbd-launch ros-kinetic-tf2-geometry-msgs python-catkin-tools -y
 
 # Install ROS dependencies
 RUN rosdep update \
@@ -35,3 +36,7 @@ RUN rosdep update \
 RUN catkin config \
       --extend /opt/ros/$ROS_DISTRO && \
     catkin build
+
+RUN echo "source /home/devel/setup.bash" >> /$HOME/.bashrc
+
+CMD "bash"

--- a/docker/melodic/Dockerfile
+++ b/docker/melodic/Dockerfile
@@ -23,7 +23,7 @@ RUN add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/a
 
 # Install required realsense and ROS packages
 RUN apt-get update && \
-    apt-get install librealsense2-dkms librealsense2-utils librealsense2-dev librealsense2-dbg python-catkin-tools -y
+    apt-get install librealsense2-dkms librealsense2-utils librealsense2-dev librealsense2-dbg ros-melodic-tf2-geometry-msgs python-catkin-tools -y
 
 WORKDIR /home/ros
 
@@ -35,3 +35,7 @@ RUN rosdep update \
 RUN catkin config \
       --extend /opt/ros/$ROS_DISTRO && \
     catkin build
+
+RUN echo "source /home/ros/devel/setup.bash" >> /$HOME/.bashrc
+
+CMD "bash"


### PR DESCRIPTION
The dockerfile was missing `apt-get install ros-melodic/kinetic-tf2-geometry-msgs`.
I was getting this error
```
Errors << orb_slam2_ros:make /home/logs/orb_slam2_ros/build.make.000.log       
In file included from /home/src/orb_slam_2_ros/ros/src/Node.cc:1:0:
/home/src/orb_slam_2_ros/ros/include/Node.h:34:49: fatal error: tf2_geometry_msgs/tf2_geometry_msgs.h: No such file or directory
compilation terminated.
make[2]: *** [CMakeFiles/orb_slam2_ros_mono.dir/ros/src/Node.cc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
In file included from /home/src/orb_slam_2_ros/ros/include/MonoNode.h:37:0,
                 from /home/src/orb_slam_2_ros/ros/src/MonoNode.cc:1:
/home/src/orb_slam_2_ros/ros/include/Node.h:34:49: fatal error: tf2_geometry_msgs/tf2_geometry_msgs.h: No such file or directory
compilation terminated.
```

I also added sourcing devel/setup.bash and bash as the default command so that it sources .bashrc (and hence devel/setup.bash), so that we can roslaunch orb_slam_2_ros right after running the Docker container.