### PR TITLE
Add dependency definition for 'tf2_geometry_msgs' and 'tf2_ros'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ std_msgs
 cv_bridge
 image_transport
 tf
+tf2_geometry_msgs
+tf2_ros
 sensor_msgs
 dynamic_reconfigure
 message_generation

--- a/package.xml
+++ b/package.xml
@@ -9,15 +9,19 @@
   <license>GPLv3</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>tf</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
+  <build_depend>tf2_ros</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>message_generation</build_depend>
+
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>std_msgs</run_depend>


### PR DESCRIPTION
## Description
Just tried manually build this package and noticed that some deps where missing, causing a fail at build phase. The main problem seems like `tf2_geometry_msgs` being missing, making the build crash. 

But I also noticed that there are headers including `tf2_ros` stuff, but no dependency is defined on it. We could get it transitively from `tf2_geometry_msgs`, but the proper way would also add a dependency definition for `tf2_ros`

## Overview
Add  'tf2_geometry_msgs' and 'tf2_ros' to package manifest and also `find_package` them at CMakeLists 