### PR TITLE
Delete Frame copy constructor and other minor fixes

### DIFF
--- a/orb_slam2/include/Frame.h
+++ b/orb_slam2/include/Frame.h
@@ -45,9 +45,6 @@ class Frame
 public:
     Frame();
 
-    // Copy constructor.
-    Frame(const Frame &frame);
-
     // Constructor for stereo cameras.
     Frame(const cv::Mat &imLeft, const cv::Mat &imRight, const double &timeStamp, ORBextractor* extractorLeft, ORBextractor* extractorRight, ORBVocabulary* voc, cv::Mat &K, cv::Mat &distCoef, const float &bf, const float &thDepth);
 

--- a/orb_slam2/src/Frame.cc
+++ b/orb_slam2/src/Frame.cc
@@ -35,29 +35,6 @@ float Frame::mfGridElementWidthInv, Frame::mfGridElementHeightInv;
 Frame::Frame()
 {}
 
-//Copy Constructor
-Frame::Frame(const Frame &frame)
-    :mpORBvocabulary(frame.mpORBvocabulary), mpORBextractorLeft(frame.mpORBextractorLeft), mpORBextractorRight(frame.mpORBextractorRight),
-     mTimeStamp(frame.mTimeStamp), mK(frame.mK.clone()), mDistCoef(frame.mDistCoef.clone()),
-     mbf(frame.mbf), mb(frame.mb), mThDepth(frame.mThDepth), N(frame.N), mvKeys(frame.mvKeys),
-     mvKeysRight(frame.mvKeysRight), mvKeysUn(frame.mvKeysUn),  mvuRight(frame.mvuRight),
-     mvDepth(frame.mvDepth), mBowVec(frame.mBowVec), mFeatVec(frame.mFeatVec),
-     mDescriptors(frame.mDescriptors.clone()), mDescriptorsRight(frame.mDescriptorsRight.clone()),
-     mvpMapPoints(frame.mvpMapPoints), mvbOutlier(frame.mvbOutlier), mnId(frame.mnId),
-     mpReferenceKF(frame.mpReferenceKF), mnScaleLevels(frame.mnScaleLevels),
-     mfScaleFactor(frame.mfScaleFactor), mfLogScaleFactor(frame.mfLogScaleFactor),
-     mvScaleFactors(frame.mvScaleFactors), mvInvScaleFactors(frame.mvInvScaleFactors),
-     mvLevelSigma2(frame.mvLevelSigma2), mvInvLevelSigma2(frame.mvInvLevelSigma2)
-{
-    for(int i=0;i<FRAME_GRID_COLS;i++)
-        for(int j=0; j<FRAME_GRID_ROWS; j++)
-            mGrid[i][j]=frame.mGrid[i][j];
-
-    if(!frame.mTcw.empty())
-        SetPose(frame.mTcw);
-}
-
-
 Frame::Frame(const cv::Mat &imLeft, const cv::Mat &imRight, const double &timeStamp, ORBextractor* extractorLeft, ORBextractor* extractorRight, ORBVocabulary* voc, cv::Mat &K, cv::Mat &distCoef, const float &bf, const float &thDepth)
     :mpORBvocabulary(voc),mpORBextractorLeft(extractorLeft),mpORBextractorRight(extractorRight), mTimeStamp(timeStamp), mK(K.clone()),mDistCoef(distCoef.clone()), mbf(bf), mThDepth(thDepth),
      mpReferenceKF(static_cast<KeyFrame*>(NULL))

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>cv_bridge</build_depend>
+  <build_depend>image_common</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>tf2_ros</build_depend>
   <build_depend>sensor_msgs</build_depend>
@@ -23,6 +24,7 @@
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>cv_bridge</exec_depend>
+  <exec_depend>image_common</exec_depend>
   <exec_depend>image_transport</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>

--- a/ros/include/MonoNode.hpp
+++ b/ros/include/MonoNode.hpp
@@ -26,7 +26,7 @@
 #include <sensor_msgs/msg/image.hpp>
 #include <opencv2/core/core.hpp>
 
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <tf2_ros/transform_broadcaster.h>
 

--- a/ros/include/Node.hpp
+++ b/ros/include/Node.hpp
@@ -21,7 +21,7 @@
 #ifndef NODE_HPP_
 #define NODE_HPP_
 
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <cv_bridge/cv_bridge.h>
 
 #include <message_filters/subscriber.h>
@@ -78,6 +78,8 @@ protected:
   ORB_SLAM2::System * orb_slam_;
   rclcpp::Time current_frame_time_;
   std::shared_ptr<image_transport::ImageTransport> image_transport_;
+
+  bool subscribe_best_effort_param_;
 
 private:
   void PublishMapPoints(std::vector<ORB_SLAM2::MapPoint *> map_points);

--- a/ros/include/RGBDNode.hpp
+++ b/ros/include/RGBDNode.hpp
@@ -25,7 +25,7 @@
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
 #include <message_filters/sync_policies/approximate_time.h>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <sensor_msgs/image_encodings.hpp>
 #include <opencv2/core/core.hpp>

--- a/ros/include/StereoNode.hpp
+++ b/ros/include/StereoNode.hpp
@@ -28,7 +28,7 @@
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
 #include <message_filters/sync_policies/approximate_time.h>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <sensor_msgs/image_encodings.hpp>
 #include <sensor_msgs/msg/image.hpp>


### PR DESCRIPTION
* remove Frame copy constructor, fixes https://github.com/appliedAI-Initiative/orb_slam_2_ros/issues/124
* add dep on `image_common`
* include `image_transport.hpp` rather than `image_transport.h`